### PR TITLE
add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,82 @@
+
+networks:
+  ollama-net:
+    driver: bridge
+  monitor-net:
+    driver: bridge
+
+volumes:
+  ollama-data:
+  open-webui-data:
+  prometheus-data:
+  grafana-data:
+
+services:
+  ollama:
+    image: ollama/ollama
+    container_name: ollama
+    ports:
+      - "127.0.0.1:11444:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    networks:
+      - ollama-net
+
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    ports:
+      - "8081:8080"
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434
+    volumes:
+      - open-webui-data:/app/backend/data
+    restart: always
+    depends_on:
+      - ollama
+    networks:
+      - ollama-net
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - prometheus-data:/prometheus
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - monitor-net
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor
+    ports:
+      - "8082:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/kmsg:/dev/kmsg
+    networks:
+      - monitor-net
+
+  node-exporter:
+    image: prom/node-exporter
+    container_name: node-exporter
+    ports:
+      - "9100:9100"
+    networks:
+      - monitor-net
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - "4001:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    networks:
+      - monitor-net
+


### PR DESCRIPTION
This PR adds a docker-compose.yml
so you just need to run `docker compose up` and then `docker exec -it ollama ollama pull llama3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Docker Compose setup for streamlined deployment of application and monitoring services.
  * Introduced persistent storage for key services to ensure data durability.
  * Enabled integrated monitoring with Prometheus, Grafana, cAdvisor, and node-exporter.
  * Established isolated networks for application and monitoring components for enhanced organization and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->